### PR TITLE
fix: 프론트 body 엔티티 타입 에러 해결

### DIFF
--- a/backend/app/api/routers/disease_prediction_router.py
+++ b/backend/app/api/routers/disease_prediction_router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 from app.api.schemas.primary_disease_prediction import (
-    User_Symptom_Input,
+    UserSymptomInput,
     PrimaryDiseasePredictionResponse,
 )
 from app.api.schemas.secondary_disease_prediction import SecondaryDiseasePredictionRequest
@@ -10,7 +10,7 @@ router = APIRouter()
 
 
 @router.post("/primary_disease_prediction/", response_model=PrimaryDiseasePredictionResponse)
-async def disease_prediction_endpoint(input_data: User_Symptom_Input):
+async def disease_prediction_endpoint(input_data: UserSymptomInput):
     return await primary_disease_prediction(input_data)
 
 @router.post("/secondary_disease_prediction/")

--- a/backend/app/api/schemas/primary_disease_prediction.py
+++ b/backend/app/api/schemas/primary_disease_prediction.py
@@ -6,7 +6,7 @@ def generate_uuid() -> str:
     return str(uuid4())
 
 #사용자가 입력한 증상
-class User_Symptom_Input(BaseModel):
+class UserSymptomInput(BaseModel):
     user_id: str
     symptoms: str
 

--- a/backend/app/services/gpt_service.py
+++ b/backend/app/services/gpt_service.py
@@ -7,7 +7,7 @@ from app.utils.api_client import get_gpt_response
 from app.api.schemas.disease_prediction_session import DiseasePredictionSession
 from app.services.firebase_service import store_user_session
 
-async def primary_disease_prediction(input_data: User_Symptom_Input):
+async def primary_disease_prediction(input_data: UserSymptomInput):
     response = await get_gpt_response(
         input_data.symptoms, PRIMARY_DISEASE_PREDICTION_PROMPT
     )

--- a/frontend/lib/gptchat.dart
+++ b/frontend/lib/gptchat.dart
@@ -28,19 +28,21 @@ class _GptPageState extends State<GptPage> {
   // 백에 증상 채팅 입력 보내고 처리.
   Future<SessionData?> responseSymptom() async {
     String text = _chatControlloer.text; // 현재 텍스트 필드의 텍스트 추출
-
+    _chatControlloer.clear(); // 텍스트 필드 클리어
     // 백엔드로 POST 요청 보내기
     try {
       http.Response response = await http.post(
         Uri.parse('http://127.0.0.1:8000/primary_disease_prediction/'),
-        body: {'symptoms': text}, // POST 요청의 바디 (메시지 데이터)
+        headers: {'Content-Type': 'application/json'}, // POST 요청의 헤더
+        body: json.encode(
+            {'user_id': '777', 'symptoms': text}), // POST 요청의 바디 (메시지 데이터)
       );
 
       if (response.statusCode == 200) {
         // 서버 응답 성공 확인
 
         // 서버의 응답에서 JSON 데이터를 파싱
-        var jsonResponse = jsonDecode(response.body);
+        var jsonResponse = jsonDecode(utf8.decode(response.bodyBytes));
 
         // 질문 각각 추출, 응답에서 "questions"를 추출하여 Map에 저장
         Map<String, String> questions = {};
@@ -77,7 +79,6 @@ class _GptPageState extends State<GptPage> {
     setState(() {
       String text = _chatControlloer.text;
       userSymptomChat.add(text); // 메시지 목록에 텍스트 추가
-      _chatControlloer.clear(); // 텍스트 필드 클리어
     });
     SessionData? sessionData = await responseSymptom();
     updateData(sessionData);


### PR DESCRIPTION
드디어 프론트에 질문이 뜹니다 와하하

### 코드 변경 이유
UTF 인코딩, 바디 엔티티 타입 에러 해결했습니다.
하는김에 겸사겸사 작명법 안맞는 백엔드 함수명 변경했음
<br>


### 스크린샷
![image](https://github.com/Handoni/Apayo/assets/101948889/7ec93f9c-98ce-41c3-a312-55dc2254e454)

<br>

### 그외 남은 구현 사항
이제 시작입니다.
<br>
