### PR TITLE
feat: 구글지도 api 불러오기

### DIFF
--- a/frontend/lib/google_map.dart
+++ b/frontend/lib/google_map.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:geolocator/geolocator.dart';
+
+void main() {
+  runApp(MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: MapScreen(),
+    );
+  }
+}
+
+class MapScreen extends StatefulWidget {
+  @override
+  _MapScreenState createState() => _MapScreenState();
+}
+
+class _MapScreenState extends State<MapScreen> {
+  late GoogleMapController mapController;
+  LatLng? _currentPosition;
+
+  @override
+  void initState() {
+    super.initState();
+    _determinePosition();
+  }
+
+  Future<void> _determinePosition() async {
+    bool serviceEnabled;
+    LocationPermission permission;
+
+    // 테스트 실행시 필요한 웹에 대한 권한요청을 한다.
+    serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) {
+      return Future.error('Location services are disabled.');
+    }
+
+    permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+      if (permission == LocationPermission.denied) {
+        return Future.error('Location permissions are denied');
+      }
+    }
+
+    if (permission == LocationPermission.deniedForever) {
+      return Future.error(
+          'Location permissions are permanently denied, we cannot request permissions.');
+    }
+
+    Position position = await Geolocator.getCurrentPosition(
+        desiredAccuracy: LocationAccuracy.high);
+    setState(() {
+      _currentPosition = LatLng(position.latitude, position.longitude);
+    });
+  }
+
+  void _onMapCreated(GoogleMapController controller) {
+    mapController = controller;
+    if (_currentPosition != null) {
+      mapController.moveCamera(
+        CameraUpdate.newLatLng(_currentPosition!),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Google Maps'),
+      ),
+      body: _currentPosition == null
+          ? Center(child: CircularProgressIndicator())
+          : GoogleMap(
+              onMapCreated: _onMapCreated,
+              initialCameraPosition: CameraPosition(
+                target: _currentPosition!,
+                zoom: 17.0,
+              ),
+            ),
+    );
+  }
+}

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -39,6 +39,8 @@ dependencies:
     # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.6
   google_maps_flutter: ^2.7.0 # flutter pub add google_maps_flutter 하면 됨
+  geolocator: ^12.0.0 # 위치 불러오기용
+  web: ^0.5.1
 
 dev_dependencies:
   flutter_test:
@@ -49,7 +51,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^3.0.0
+  flutter_lints: ^4.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/frontend/web/index.html
+++ b/frontend/web/index.html
@@ -38,6 +38,7 @@
   </script>
   <!-- This script adds the flutter initialization JS code -->
   <script src="flutter.js" defer></script>
+  <script src="https://maps.googleapis.com/maps/api/js?key= 여기에 api키 추가하세용"></script>
 </head>
 <body>
   <script>


### PR DESCRIPTION
### 코드 변경 이유
구글 지도 불러오기 추가
<br>

### 발견된 위험이나 장애
거리가 3번 뜸 -> 나중에 수정
<br>

### 리뷰어가 집중할 부분
실행시, index.html 에 api 키 부분에 api 추가해야합니다
실행시, 웹사이트 주소 보내주시면 등록해드릴게요
구현 완료될때까지 google_map.dart 에서 바로 실행되게 해뒀습니다.

<br>

### 스크린샷

![image](https://github.com/Handoni/Apayo/assets/166142544/2180530f-3050-4705-b8ec-28734176869f)

<br>

### 그외 남은 구현 사항
병원위치 불러오기 -> 3차 병원  아이콘으로 표시
병원 정보 불러오기
 <br>
